### PR TITLE
Add stdout and stdout_lines to django manage output

### DIFF
--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -297,7 +297,8 @@ def main():
             changed = filtered_output
 
     module.exit_json(changed=changed, out=out, cmd=cmd, app_path=app_path, virtualenv=virtualenv,
-                     settings=module.params['settings'], pythonpath=module.params['pythonpath'])
+                     settings=module.params['settings'], pythonpath=module.params['pythonpath'],
+                     stdout=out, stdout_lines=lines)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY

Many ansible tasks use the syntax of `stdout` or `stdout_lines` (for a list) when returning output. django_manage just uses `out`.

This PR simply adds support for `stdout` and `stdout_lines` to the django_manage module.

Top google answer for "ansible show stdout":
https://serverfault.com/questions/537060/how-to-see-stdout-of-ansible-commands

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
django_manage

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
